### PR TITLE
Odt export support

### DIFF
--- a/action.php
+++ b/action.php
@@ -22,7 +22,7 @@ class action_plugin_exttab3 extends DokuWiki_Action_Plugin {
         $controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'handle_toolbar', array ());
     }
 
-    public function handle_toolbar(&$event, $param) {
+    public function handle_toolbar(Doku_Event $event, $param) {
         $event->data[] = array (
             'type' => 'picker',
             'title' => 'extended table typical patterns',

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -29,52 +29,42 @@ class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
             $style = trim($style, ' "');
         }
 
+        // class to get CSS Properties by $render->getODTProperties()
+        $class = 'dokuwiki exttab3';
+
         switch ( $state ) {
             case DOKU_LEXER_ENTER:    // open tag
+                // Get CSS properties for ODT export.
+                $renderer->getODTProperties($properties, $tag, $class, $style);
+
                 switch ($tag) {
                     case 'table':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties($properties, 'table', 'dokuwiki exttab3', $style);
-
                         $renderer->_odtTableOpenUseProperties($properties);
                         break;
                     case 'caption':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties($properties, 'caption', 'dokuwiki exttab3', $style);
-
                         $renderer->_odtTableRowOpenUseProperties($properties);
 
                         // Parameter 'colspan=0' indicates spann across all columns!
                         $renderer->_odtTableHeaderOpenUseProperties($properties, 0, 1);
                         break;
                     case 'th':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties($properties, 'th', 'dokuwiki exttab3', $style);
-
                         $renderer->_odtTableHeaderOpenUseProperties($properties);
                         $renderer->_odtTableAddColumnUseProperties($properties);
                         break;
                     case 'tr':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties($properties, 'tr', 'dokuwiki exttab3', $style);
-                        
                         $renderer->_odtTableRowOpenUseProperties($properties);
                         break;
                     case 'td':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties($properties, 'td', 'dokuwiki exttab3', $style);
-
                         $renderer->_odtTableCellOpenUseProperties($properties);
                         break;
                 }
-                //$renderer->doc.= $this->_open($tag, $attr);
                 break;
             case DOKU_LEXER_MATCHED:  // defensive, shouldn't occur
+                break;
             case DOKU_LEXER_UNMATCHED:
                 $renderer->cdata($tag);
                 break;
             case DOKU_LEXER_EXIT:     // close tag
-                //$renderer->doc.= $this->_close($tag);
                 switch ($tag) {
                     case 'table':
                         //$renderer->table_close();

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -11,23 +11,22 @@ if(!defined('DOKU_INC')) die();
 class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
 
     function render(Doku_Renderer $renderer, $data) {
-        $properties = array ();
+        $properties = array();
 
         // Return if installed ODT plugin version is too old.
-        if ( method_exists ($renderer, 'getODTProperties') === false ||
-             method_exists ($renderer, '_odtTableAddColumnUseProperties') === false ) {
-            return;
+        if ( method_exists($renderer, 'getODTProperties') == false ||
+             method_exists($renderer, '_odtTableAddColumnUseProperties') == false ) {
+            return false;
         }
 
         //list($tag, $state, $match) = $data;
         list($state, $tag, $attr) = $data;
 
         // Get style content
-        preg_match ('/style=".*"/', $attr, $matches);
-        $style = "";
-        if ( empty ($matches [0]) === false ) {
-            $style = substr ($matches [0], 6);
-            $style = trim ($style, ' "');
+        $style = '';
+        if (preg_match('/style=".*"/', $attr, $matches) === 1) {
+            $style = substr($matches[0], 6);
+            $style = trim($style, ' "');
         }
 
         switch ( $state ) {
@@ -35,13 +34,13 @@ class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
                 switch ($tag) {
                     case 'table':
                         // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'table', 'dokuwiki exttab3', $style);
+                        $renderer->getODTProperties($properties, 'table', 'dokuwiki exttab3', $style);
 
                         $renderer->_odtTableOpenUseProperties($properties);
                         break;
                     case 'caption':
                         // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'caption', 'dokuwiki exttab3', $style);
+                        $renderer->getODTProperties($properties, 'caption', 'dokuwiki exttab3', $style);
 
                         $renderer->_odtTableRowOpenUseProperties($properties);
 
@@ -50,20 +49,20 @@ class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
                         break;
                     case 'th':
                         // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'th', 'dokuwiki exttab3', $style);
+                        $renderer->getODTProperties($properties, 'th', 'dokuwiki exttab3', $style);
 
                         $renderer->_odtTableHeaderOpenUseProperties($properties);
                         $renderer->_odtTableAddColumnUseProperties($properties);
                         break;
                     case 'tr':
                         // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'tr', 'dokuwiki exttab3', $style);
+                        $renderer->getODTProperties($properties, 'tr', 'dokuwiki exttab3', $style);
                         
                         $renderer->_odtTableRowOpenUseProperties($properties);
                         break;
                     case 'td':
                         // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'td', 'dokuwiki exttab3', $style);
+                        $renderer->getODTProperties($properties, 'td', 'dokuwiki exttab3', $style);
 
                         $renderer->_odtTableCellOpenUseProperties($properties);
                         break;
@@ -78,8 +77,8 @@ class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
                 //$renderer->doc.= $this->_close($tag);
                 switch ($tag) {
                     case 'table':
-                            //$renderer->table_close();
-                            $renderer->_odtTableClose();
+                        //$renderer->table_close();
+                        $renderer->_odtTableClose();
                         break;
                     case 'caption':
                         $renderer->tableheader_close();

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * ODT (Open Document format) export for Exttab3 plugin
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Lars (LarsDW223)
+ */
+
+if(!defined('DOKU_INC')) die();
+
+class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
+
+    function render(Doku_Renderer $renderer, $data) {
+        $properties = array ();
+
+        // Return if installed ODT plugin version is too old.
+        if ( method_exists ($renderer, 'getODTProperties') === false ||
+             method_exists ($renderer, '_odtTableAddColumnUseProperties') === false ) {
+            return;
+        }
+
+        //list($tag, $state, $match) = $data;
+        list($state, $tag, $attr) = $data;
+
+        // Get style content
+        preg_match ('/style=".*"/', $attr, $matches);
+        $style = "";
+        if ( empty ($matches [0]) === false ) {
+            $style = substr ($matches [0], 6);
+            $style = trim ($style, ' "');
+        }
+
+        switch ( $state ) {
+            case DOKU_LEXER_ENTER:    // open tag
+                switch ($tag) {
+                    case 'table':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'table', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableOpenUseProperties($properties);
+                        break;
+                    case 'caption':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'caption', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableRowOpenUseProperties($properties);
+
+                        // Parameter 'colspan=0' indicates spann across all columns!
+                        $renderer->_odtTableHeaderOpenUseProperties($properties, 0, 1);
+                        break;
+                    case 'th':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'th', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableHeaderOpenUseProperties($properties);
+                        $renderer->_odtTableAddColumnUseProperties($properties);
+                        break;
+                    case 'tr':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'tr', 'dokuwiki exttab3', $style);
+                        
+                        $renderer->_odtTableRowOpenUseProperties($properties);
+                        break;
+                    case 'td':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'td', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableCellOpenUseProperties($properties);
+                        break;
+                }
+                //$renderer->doc.= $this->_open($tag, $attr);
+                break;
+            case DOKU_LEXER_MATCHED:  // defensive, shouldn't occur
+            case DOKU_LEXER_UNMATCHED:
+                $renderer->cdata($tag);
+                break;
+            case DOKU_LEXER_EXIT:     // close tag
+                //$renderer->doc.= $this->_close($tag);
+                switch ($tag) {
+                    case 'table':
+                            //$renderer->table_close();
+                            $renderer->_odtTableClose();
+                        break;
+                    case 'caption':
+                        $renderer->tableheader_close();
+                        $renderer->tablerow_close();
+                        break;
+                    case 'th':
+                        $renderer->tableheader_close();
+                        break;
+                    case 'tr':
+                        $renderer->tablerow_close();
+                        break;
+                    case 'td':
+                        $renderer->p_close();
+                        $renderer->tablecell_close();
+                        break;
+                }
+                break;
+        }
+    }
+}

--- a/helper/odt.php
+++ b/helper/odt.php
@@ -30,7 +30,7 @@ class helper_plugin_exttab3_odt extends DokuWiki_Plugin {
         }
 
         // class to get CSS Properties by $render->getODTProperties()
-        $class = 'dokuwiki exttab3';
+        $class = 'exttable';
 
         switch ( $state ) {
             case DOKU_LEXER_ENTER:    // open tag

--- a/odt.css
+++ b/odt.css
@@ -1,0 +1,17 @@
+/********************************************************************
+ODT-Export Styles for the Exttab3 Plugin
+********************************************************************/
+
+.dokuwiki th.exttab3 {
+    border: 1pt solid __border__;
+    padding: 0.5em;
+    background-color: __background_alt__;
+    color: __text__;
+    font-weight:bold;
+}
+
+.dokuwiki td.exttab3 {
+    border: 1pt solid __border__;
+    padding: 0.5em;
+}
+

--- a/odt.css
+++ b/odt.css
@@ -2,7 +2,7 @@
 ODT-Export Styles for the Exttab3 Plugin
 ********************************************************************/
 
-.dokuwiki th.exttab3 {
+.exttable th {
     border: 1pt solid __border__;
     padding: 0.5em;
     background-color: __background_alt__;
@@ -10,7 +10,7 @@ ODT-Export Styles for the Exttab3 Plugin
     font-weight:bold;
 }
 
-.dokuwiki td.exttab3 {
+.exttable td {
     border: 1pt solid __border__;
     padding: 0.5em;
 }

--- a/style.css
+++ b/style.css
@@ -1,13 +1,13 @@
 /*
  * DokuWiki Plugin ExtTab3 style.css
  */
-div.exttab p {
+.exttable p {
     margin-bottom: 0;
 }
-div.exttab ol {
+.exttable ol {
     padding-left: 0em;
 }
-div.exttab ul {
+.exttable ul {
     padding-left: 0em;
 }
 

--- a/syntax.php
+++ b/syntax.php
@@ -26,13 +26,17 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
 
         // define name, prefix and postfix of tags
         $this->tagsmap = array(
-                'table'   => array("", "\n" ),        // table start  : {|
-                '/table'  => array("", ""),           // table end    : |}
-                'caption' => array("\t", "\n" ),      // caption      : |+
-                'tr'      => array("\t", "\n" ),      // table row    : |-
-                'th'      => array("\t"."\t", "\n" ), // table header : !
-                'td'      => array("\t"."\t", "\n" ), // table data   : |
                 'div'     => array("", "\n" ),        // wrapper
+                'table'   => array("", "\n" ),        // table start  : {|
+                '/table'  => array("\n", ""),         // table end    : |}
+                'caption' => array("", "" ),          // caption      : |+
+                '/caption'=> array("", ""),
+                'tr'      => array("\n", "\n"),       // table row    : |-
+                '/tr'     => array("\n", ""),
+                'th'      => array("", "" ),          // table header : !
+                '/th'     => array("", ""),
+                'td'      => array("", "" ),          // table data   : |
+                '/td'     => array("", ""),
         );
 
         // define allowable attibutes for table tags
@@ -329,8 +333,8 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
      * @return string             html used to close the tag
      */
     protected function _close($tag) {
-        $before = $this->tagsmap[$tag][0];
-        $after  = $this->tagsmap[$tag][1];
+        $before = $this->tagsmap['/'.$tag][0];
+        $after  = $this->tagsmap['/'.$tag][1];
         return $before.'</'.$tag.'>'.$after;
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -6,7 +6,6 @@
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * @author     Satoshi Sahara <sahara.satoshi@gmail.com>
- * @date       2014-11-20
  */
  
 // must be run within Dokuwiki

--- a/syntax.php
+++ b/syntax.php
@@ -59,7 +59,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
     function getPType(){ return 'block';}
     function getSort(){  return 59; } // = Doku_Parser_Mode_table-1
     function getAllowedTypes() { 
-        return array('container', 'formatting', 'substition', 'disabled', 'protected'); 
+        return array('container', 'formatting', 'substition', 'disabled', 'protected', 'paragraphs');
     }
 
     /**

--- a/syntax.php
+++ b/syntax.php
@@ -26,17 +26,13 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
 
         // define name, prefix and postfix of tags
         $this->tagsmap = array(
-                'div'     => array("", "\n" ),        // wrapper
                 'table'   => array("", "\n" ),        // table start  : {|
-                '/table'  => array("\n", ""),         // table end    : |}
-                'caption' => array("", "" ),          // caption      : |+
-                '/caption'=> array("", ""),
-                'tr'      => array("\n", "\n"),       // table row    : |-
-                '/tr'     => array("\n", ""),
-                'th'      => array("", "" ),          // table header : !
-                '/th'     => array("", ""),
-                'td'      => array("", "" ),          // table data   : |
-                '/td'     => array("", ""),
+                '/table'  => array("", ""),           // table end    : |}
+                'caption' => array("\t", "\n" ),      // caption      : |+
+                'tr'      => array("\t", "\n" ),      // table row    : |-
+                'th'      => array("\t"."\t", "\n" ), // table header : !
+                'td'      => array("\t"."\t", "\n" ), // table data   : |
+                'div'     => array("", "\n" ),        // wrapper
         );
 
         // define allowable attibutes for table tags
@@ -333,8 +329,8 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
      * @return string             html used to close the tag
      */
     protected function _close($tag) {
-        $before = $this->tagsmap['/'.$tag][0];
-        $after  = $this->tagsmap['/'.$tag][1];
+        $before = $this->tagsmap[$tag][0];
+        $after  = $this->tagsmap[$tag][1];
         return $before.'</'.$tag.'>'.$after;
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -26,13 +26,18 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
 
         // define name, prefix and postfix of tags
         $this->tagsmap = array(
-                'table'   => array("", "\n" ),        // table start  : {|
-                '/table'  => array("", ""),           // table end    : |}
-                'caption' => array("\t", "\n" ),      // caption      : |+
-                'tr'      => array("\t", "\n" ),      // table row    : |-
-                'th'      => array("\t"."\t", "\n" ), // table header : !
-                'td'      => array("\t"."\t", "\n" ), // table data   : |
                 'div'     => array("", "\n" ),        // wrapper
+                '/div'    => array("", "\n" ),
+                'table'   => array("", "\n" ),        // table start  : {|
+                '/table'  => array("", "\n"),         // table end    : |}
+                'caption' => array("", "" ),          // caption      : |+
+                '/caption'=> array("", "\n"),
+                'tr'      => array("", "\n"),         // table row    : |-
+                '/tr'     => array("", "\n"),
+                'th'      => array("", "" ),          // table header : !
+                '/th'     => array("", "\n"),
+                'td'      => array("", "" ),          // table data   : |
+                '/td'     => array("", "\n"),
         );
 
         // define allowable attibutes for table tags
@@ -329,8 +334,8 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
      * @return string             html used to close the tag
      */
     protected function _close($tag) {
-        $before = $this->tagsmap[$tag][0];
-        $after  = $this->tagsmap[$tag][1];
+        $before = $this->tagsmap['/'.$tag][0];
+        $after  = $this->tagsmap['/'.$tag][1];
         return $before.'</'.$tag.'>'.$after;
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -279,6 +279,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
 
         switch ($format) {
             case 'xhtml' : return $this->render_xhtml($renderer, $data);
+            case 'odt'   : return $this->render_odt($renderer, $data);
             default:
                 return true;
         }
@@ -299,6 +300,96 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
                 break;
             case DOKU_LEXER_EXIT:     // close tag
                 $renderer->doc.= $this->_close($tag);
+                break;
+        }
+    }
+
+    protected function render_odt(&$renderer, $data) {
+        $properties = array ();
+
+        // Return if installed ODT plugin version is too old.
+        if ( method_exists ($renderer, 'getODTProperties') === false ||
+             method_exists ($renderer, '_odtTableAddColumnUseProperties') === false ) {
+            return;
+        }
+
+        //list($tag, $state, $match) = $data;
+        list($state, $tag, $attr) = $data;
+
+        // Get style content
+        preg_match ('/style=".*"/', $attr, $matches);
+        $style = "";
+        if ( empty ($matches [0]) === false ) {
+            $style = substr ($matches [0], 6);
+            $style = trim ($style, ' "');
+        }
+
+        switch ( $state ) {
+            case DOKU_LEXER_ENTER:    // open tag
+                switch ($tag) {
+                    case 'table':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'table', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableOpenUseProperties($properties);
+                        break;
+                    case 'caption':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'caption', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableRowOpenUseProperties($properties);
+
+                        // Parameter 'colspan=0' indicates spann across all columns!
+                        $renderer->_odtTableHeaderOpenUseProperties($properties, 0, 1);
+                        break;
+                    case 'th':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'th', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableHeaderOpenUseProperties($properties);
+                        $renderer->_odtTableAddColumnUseProperties($properties);
+                        break;
+                    case 'tr':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'tr', 'dokuwiki exttab3', $style);
+                        
+                        $renderer->_odtTableRowOpenUseProperties($properties);
+                        break;
+                    case 'td':
+                        // Get CSS properties for ODT export.
+                        $renderer->getODTProperties ($properties, 'td', 'dokuwiki exttab3', $style);
+
+                        $renderer->_odtTableCellOpenUseProperties($properties);
+                        break;
+                }
+                //$renderer->doc.= $this->_open($tag, $attr);
+                break;
+            case DOKU_LEXER_MATCHED:  // defensive, shouldn't occur
+            case DOKU_LEXER_UNMATCHED:
+                $renderer->cdata($tag);
+                break;
+            case DOKU_LEXER_EXIT:     // close tag
+                //$renderer->doc.= $this->_close($tag);
+                switch ($tag) {
+                    case 'table':
+                            //$renderer->table_close();
+                            $renderer->_odtTableClose();
+                        break;
+                    case 'caption':
+                        $renderer->tableheader_close();
+                        $renderer->tablerow_close();
+                        break;
+                    case 'th':
+                        $renderer->tableheader_close();
+                        break;
+                    case 'tr':
+                        $renderer->tablerow_close();
+                        break;
+                    case 'td':
+                        $renderer->p_close();
+                        $renderer->tablecell_close();
+                        break;
+                }
                 break;
         }
     }

--- a/syntax.php
+++ b/syntax.php
@@ -294,7 +294,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
         return false;
     }
 
-    protected function render_xhtml(&$renderer, $data) {
+    protected function render_xhtml(Doku_Renderer $renderer, $data) {
         //list($tag, $state, $match) = $data;
         list($state, $tag, $attr) = $data;
 

--- a/syntax.php
+++ b/syntax.php
@@ -278,8 +278,11 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
         if (empty($data)) return false;
 
         switch ($format) {
-            case 'xhtml' : return $this->render_xhtml($renderer, $data);
-            case 'odt'   : return $this->render_odt($renderer, $data);
+            case 'xhtml' :
+                return $this->render_xhtml($renderer, $data);
+            case 'odt'   :
+                $this->loadHelper('exttab3_odt');
+                return $odt->render($renderer, $data);
             default:
                 return true;
         }
@@ -304,95 +307,6 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
         }
     }
 
-    protected function render_odt(&$renderer, $data) {
-        $properties = array ();
-
-        // Return if installed ODT plugin version is too old.
-        if ( method_exists ($renderer, 'getODTProperties') === false ||
-             method_exists ($renderer, '_odtTableAddColumnUseProperties') === false ) {
-            return;
-        }
-
-        //list($tag, $state, $match) = $data;
-        list($state, $tag, $attr) = $data;
-
-        // Get style content
-        preg_match ('/style=".*"/', $attr, $matches);
-        $style = "";
-        if ( empty ($matches [0]) === false ) {
-            $style = substr ($matches [0], 6);
-            $style = trim ($style, ' "');
-        }
-
-        switch ( $state ) {
-            case DOKU_LEXER_ENTER:    // open tag
-                switch ($tag) {
-                    case 'table':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'table', 'dokuwiki exttab3', $style);
-
-                        $renderer->_odtTableOpenUseProperties($properties);
-                        break;
-                    case 'caption':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'caption', 'dokuwiki exttab3', $style);
-
-                        $renderer->_odtTableRowOpenUseProperties($properties);
-
-                        // Parameter 'colspan=0' indicates spann across all columns!
-                        $renderer->_odtTableHeaderOpenUseProperties($properties, 0, 1);
-                        break;
-                    case 'th':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'th', 'dokuwiki exttab3', $style);
-
-                        $renderer->_odtTableHeaderOpenUseProperties($properties);
-                        $renderer->_odtTableAddColumnUseProperties($properties);
-                        break;
-                    case 'tr':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'tr', 'dokuwiki exttab3', $style);
-                        
-                        $renderer->_odtTableRowOpenUseProperties($properties);
-                        break;
-                    case 'td':
-                        // Get CSS properties for ODT export.
-                        $renderer->getODTProperties ($properties, 'td', 'dokuwiki exttab3', $style);
-
-                        $renderer->_odtTableCellOpenUseProperties($properties);
-                        break;
-                }
-                //$renderer->doc.= $this->_open($tag, $attr);
-                break;
-            case DOKU_LEXER_MATCHED:  // defensive, shouldn't occur
-            case DOKU_LEXER_UNMATCHED:
-                $renderer->cdata($tag);
-                break;
-            case DOKU_LEXER_EXIT:     // close tag
-                //$renderer->doc.= $this->_close($tag);
-                switch ($tag) {
-                    case 'table':
-                            //$renderer->table_close();
-                            $renderer->_odtTableClose();
-                        break;
-                    case 'caption':
-                        $renderer->tableheader_close();
-                        $renderer->tablerow_close();
-                        break;
-                    case 'th':
-                        $renderer->tableheader_close();
-                        break;
-                    case 'tr':
-                        $renderer->tablerow_close();
-                        break;
-                    case 'td':
-                        $renderer->p_close();
-                        $renderer->tablecell_close();
-                        break;
-                }
-                break;
-        }
-    }
 
     /**
      * open a exttab tag, used by render_xhtml()

--- a/syntax.php
+++ b/syntax.php
@@ -139,7 +139,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 // wrapper open
-                $this->_writeCall('div', 'class="exttab"', DOKU_LEXER_ENTER, $pos,$match,$handler);
+                $this->_writeCall('div', 'class="exttable"', DOKU_LEXER_ENTER, $pos,$match,$handler);
                 // table start
                 list($tag, $attr) = $this->_resolve_markup($match);
                 array_push($this->stack, $tag);

--- a/syntax.php
+++ b/syntax.php
@@ -281,7 +281,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
             case 'xhtml' :
                 return $this->render_xhtml($renderer, $data);
             case 'odt'   :
-                $this->loadHelper('exttab3_odt');
+                $odt = $this->loadHelper('exttab3_odt');
                 return $odt->render($renderer, $data);
             default:
                 return true;


### PR DESCRIPTION
New feature:
* merge PR #7 (ODT export support) from @LarsGit223, even though `odt.css` may need more work around to get same looks as browser view or print image. 
* wrapper class name changed to "**exttable**" instead of "exttab".
* Paragraphs in table cell made available for better odt rendering. Need one blank line after cell data narkup. Example:
```
{|
|

A1 (paragraph) <td><p>A1</p></td>
|
B1 (data) <td>B1</td>
|}
```
