### PR TITLE
Add support for ODT plugins PDF export

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -286,6 +286,7 @@ class syntax_plugin_exttab3 extends DokuWiki_Syntax_Plugin {
             case 'xhtml' :
                 return $this->render_xhtml($renderer, $data);
             case 'odt'   :
+            case 'odt_pdf':
                 $odt = $this->loadHelper('exttab3_odt');
                 return $odt->render($renderer, $data);
             default:


### PR DESCRIPTION
The exttable plugin breaks the PDF export in the ODT plugin, since the ODT plugin uses a distinct rendering mode "odt_pdf" for that. This patch recognizes that rendering mode and uses the ODT helper, just like for regular "odt" rendering.